### PR TITLE
Move more info into generic attribute and split out interface details discovery

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -412,7 +412,7 @@ public partial interface IComInterface1 : IUnmanagedInterfaceType<InterfaceId>
 public partial interface IComInterface2 : IUnmanagedInterfaceType<InterfaceId>
 {
     static InterfaceId IUnmanagedInterfaceType<InterfaceId>.TypeKey => new(new Guid(ComProxies.Iids.Slice(1 * 16, 16)));
-    static int IUnmanagedInterfaceType<InterfaceId>.VTableLength => 4;
+    static int IUnmanagedInterfaceType<InterfaceId>.VTableLength => 5;
 
     [DynamicInterfaceCastableImplementation]
     internal interface Impl : IComInterface2


### PR DESCRIPTION
This PR does three things:

1. Move some code around to different regions to represent (what I feel) is an easier to understand split between what is user-written, what is generated, and what is in-box.
2. Move the information about the "implementation" interface into the generic attribute's type list instead of passing it as another static abstract on `IUnmanagedInterfaceType`.
3. Split out the concept of "get interface information from `RuntimeTypeHandle`" into its own strategy. The existing implementation in the main branch requires both the IUnknown and caching strategies to understand how to look up the interface info. With this change, neither of those interfaces need to know how to lookup the info on the attribute. Additionally, user's can customize how they map from an interface to it's information if they want to do things to increase performance that aren't 100% technically correct but work in all their use cases.